### PR TITLE
Disabled merging draft PRs

### DIFF
--- a/.github/workflows/check-draft.yml
+++ b/.github/workflows/check-draft.yml
@@ -1,0 +1,20 @@
+name: Check Draft
+
+on:
+  pull_request:
+#    branches:
+#      - main
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  fail-for-draft:
+    if: contains(github.event.pull_request.labels.*.name, 'draft')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is a draft
+        run: |
+          echo "This PR is currently a draft."
+          exit 1


### PR DESCRIPTION
Adding the `draft` label to PRs will cause the fail-for-draft job in the CI to fail.

Solution from: 
- https://stackoverflow.com/questions/71502652/prevent-merging-of-branch-conditionally-based-on-label
- https://stackoverflow.com/questions/58654530/how-to-auto-reject-a-pull-request-if-tests-are-failing-github-actions