### PR TITLE
Added player names in score

### DIFF
--- a/python/tennis1.py
+++ b/python/tennis1.py
@@ -27,6 +27,9 @@ class EqualScoringService(ScoringService):
 
 
 class DifferentScoringService(ScoringService):
+    def __init__(self, player1: str, player2: str):
+        self.player1 = player1
+        self.player2 = player2
 
     def can_handle(self, p1points, p2points) -> bool:
         return p1points >= 4 or p2points >= 4
@@ -34,13 +37,13 @@ class DifferentScoringService(ScoringService):
     def score(self, p1points, p2points) -> str:
         minusResult = p1points - p2points
         if (minusResult == 1):
-            return "Advantage player1"
+            return f"Advantage {self.player1}"
         elif (minusResult == -1):
-            return "Advantage player2"
+            return f"Advantage {self.player2}"
         elif (minusResult >= 2):
-            return "Win for player1"
+            return f"Win for {self.player1}"
         else:
-            return "Win for player2"
+            return f"Win for {self.player2}"
 
 
 class GenericScoringService(ScoringService):
@@ -65,7 +68,7 @@ class TennisGame1:
         self.player2Name = player2Name
         self.p1points = 0
         self.p2points = 0
-        self.services = [EqualScoringService(), DifferentScoringService(), GenericScoringService()]
+        self.services = [EqualScoringService(), DifferentScoringService(player1=self.player1Name, player2=self.player2Name), GenericScoringService()]
 
     def won_point(self, playerName):
         if playerName == self.player1Name:

--- a/python/tennis2.py
+++ b/python/tennis2.py
@@ -72,15 +72,15 @@ class TennisGame2:
             result = P1res + "-" + P2res
 
         if (self.p1points > self.p2points and self.p2points >= 3):
-            result = "Advantage player1"
+            result = f"Advantage {self.player1Name}"
 
         if (self.p2points > self.p1points and self.p1points >= 3):
-            result = "Advantage player2"
+            result = f"Advantage {self.player2Name}"
 
         if (self.p1points>=4 and self.p2points>=0 and (self.p1points-self.p2points)>=2):
-            result = "Win for player1"
+            result = f"Win for {self.player1Name}"
         if (self.p2points>=4 and self.p1points>=0 and (self.p2points-self.p1points)>=2):
-            result = "Win for player2"
+            result = f"Win for {self.player2Name}"
         return result
 
     def SetP1Score(self, number):

--- a/python/tennis_unittest.py
+++ b/python/tennis_unittest.py
@@ -36,17 +36,17 @@ test_cases = [
     (4, 2, "Win for player1", 'player1', 'player2'),
     (2, 4, "Win for player2", 'player1', 'player2'),
 
-    (4, 3, "Advantage player1", 'player1', 'player2'),
-    (3, 4, "Advantage player2", 'player1', 'player2'),
-    (5, 4, "Advantage player1", 'player1', 'player2'),
-    (4, 5, "Advantage player2", 'player1', 'player2'),
-    (15, 14, "Advantage player1", 'player1', 'player2'),
-    (14, 15, "Advantage player2", 'player1', 'player2'),
+    (4, 3, "Advantage player 1", 'player 1', 'player 2'),
+    (3, 4, "Advantage player 2", 'player 1', 'player 2'),
+    (5, 4, "Advantage player 1", 'player 1', 'player 2'),
+    (4, 5, "Advantage player 2", 'player 1', 'player 2'),
+    (15, 14, "Advantage player 1", 'player 1', 'player 2'),
+    (14, 15, "Advantage player 2", 'player 1', 'player 2'),
 
-    (6, 4, 'Win for player1', 'player1', 'player2'),
-    (4, 6, 'Win for player2', 'player1', 'player2'),
-    (16, 14, 'Win for player1', 'player1', 'player2'),
-    (14, 16, 'Win for player2', 'player1', 'player2'),
+    (6, 4, 'Win for player 1', 'player 1', 'player 2'),
+    (4, 6, 'Win for player 2', 'player 1', 'player 2'),
+    (16, 14, 'Win for player 1', 'player 1', 'player 2'),
+    (14, 16, 'Win for player 2', 'player 1', 'player 2'),
 
 ]
 

--- a/python/tennis_unittest.py
+++ b/python/tennis_unittest.py
@@ -36,17 +36,17 @@ test_cases = [
     (4, 2, "Win for player1", 'player1', 'player2'),
     (2, 4, "Win for player2", 'player1', 'player2'),
 
-    (4, 3, "Advantage player 1", 'player 1', 'player 2'),
-    (3, 4, "Advantage player 2", 'player 1', 'player 2'),
-    (5, 4, "Advantage player 1", 'player 1', 'player 2'),
-    (4, 5, "Advantage player 2", 'player 1', 'player 2'),
-    (15, 14, "Advantage player 1", 'player 1', 'player 2'),
-    (14, 15, "Advantage player 2", 'player 1', 'player 2'),
+    (4, 3, "Advantage Tom", 'Tom', 'Jane'),
+    (3, 4, "Advantage Jane", 'Tom', 'Jane'),
+    (5, 4, "Advantage Tom", 'Tom', 'Jane'),
+    (4, 5, "Advantage Jane", 'Tom', 'Jane'),
+    (15, 14, "Advantage Tom", 'Tom', 'Jane'),
+    (14, 15, "Advantage Jane", 'Tom', 'Jane'),
 
-    (6, 4, 'Win for player 1', 'player 1', 'player 2'),
-    (4, 6, 'Win for player 2', 'player 1', 'player 2'),
-    (16, 14, 'Win for player 1', 'player 1', 'player 2'),
-    (14, 16, 'Win for player 2', 'player 1', 'player 2'),
+    (6, 4, 'Win for Tom', 'Tom', 'Jane'),
+    (4, 6, 'Win for Jane', 'Tom', 'Jane'),
+    (16, 14, 'Win for Tom', 'Tom', 'Jane'),
+    (14, 16, 'Win for Jane', 'Tom', 'Jane'),
 
 ]
 


### PR DESCRIPTION
Addressing the following kata from the Readme.md

> There is a deliberate error in several of the implementations - the player names are hard-coded to "player1" and "player2". After you refactor, you may want to fix this problem and add suitable test cases to prove your fix works.
